### PR TITLE
Bare metal QEMU compatible sample.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ qemu
 qemu-build
 initramfs
 initramfs-busybox-riscv64.cpio.gz
+baremetal
+generic-elf

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Run a RISC-V code in Qemu.
+Run a RISC-V code in QEMU.
 
 Bare metal RISC-V assembly in QEMU
 =================================

--- a/README.md
+++ b/README.md
@@ -1,3 +1,22 @@
+Run a RISC-V code in Qemu.
+
+Bare metal RISC-V assembly in QEMU
+=================================
+
+Run a bare metal RISC-V code in QEMU without any OS or C. Based on the source code from [here][riscv-hello-asm].
+
+The code supports 64bit `sifive_u` QEMU emulation target.
+
+As of this writing, these are the latest versions of the software involved:
+* Qemu: `v5.1.0`
+
+Make targets
+------------
+
+`make run-baremetal` -- build payload file and boot it via QEMU.
+
+RISC-V Linux in QEMU
+====================
 
 Run a RISC-V Linux system in Qemu. Based on instructions provided
 [here][riscv-qemu-docs] and [here][custom-kernel-tutorial].
@@ -6,7 +25,6 @@ Documents the steps to build a Qemu locally, a custom Linux kernel, and Busybox
 tools, as well as an initrd image.
 
 As of this writing, these are the latest versions of the software involved:
-
 * Qemu: `v5.1.0`
 * Linux: `v5.9`
 * Busybox: `1_9_2`
@@ -17,11 +35,24 @@ Make targets
 `make prereqs` -- apt-get the prerequisites.
 `make clone` -- clone the relevant source code.
 `make qemu` -- build Qemu for RISC-V.
-`make linux`
-`make busybox`
-`make initrd`
-`make run`
+
+`make run-linux` -- build Linux bootable image, add our executable and launch via QEMU.
+
+RISC-V ELF executable in SPIKE
+=================================
+
+Run a RISC-V ELF executable in [SPIKE][spike] a standard RISC-V ISA simulator.
+
+As of this writing, these are the latest versions of the software involved:
+* Qemu: `v5.1.0`
+* Spike" `v1.0.1-dev`
+
+TODO: install Spike
+
+`make run-spike` -- build RISC-V ELF executable and launch it via SPIKE.
 
 [riscv-qemu-docs]: https://risc-v-getting-started-guide.readthedocs.io/en/latest/linux-qemu.html
 [custom-kernel-tutorial]: http://mgalgs.github.io/2015/05/16/how-to-build-a-custom-linux-kernel-for-qemu-2015-edition.html
+[riscv-hello-asm]: https://github.com/noteed/riscv-hello-asm
+[spike]: https://github.com/riscv/riscv-isa-sim
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Run a RISC-V code in QEMU.
 Bare metal RISC-V assembly in QEMU
 =================================
 
-Run a bare metal RISC-V code in QEMU without any OS or C. Based on the source code from [here][riscv-hello-asm].
+Run a bare metal RISC-V code in QEMU without any OS or C. Based on the source code from [here][riscv-hello-asm] and [here][riscv-hello-asm2].
 
 The code supports 64bit `sifive_u` QEMU emulation target.
 
@@ -54,5 +54,6 @@ TODO: install Spike
 [riscv-qemu-docs]: https://risc-v-getting-started-guide.readthedocs.io/en/latest/linux-qemu.html
 [custom-kernel-tutorial]: http://mgalgs.github.io/2015/05/16/how-to-build-a-custom-linux-kernel-for-qemu-2015-edition.html
 [riscv-hello-asm]: https://github.com/noteed/riscv-hello-asm
+[riscv-hello-asm2]: https://theintobooks.wordpress.com/2019/12/28/hello-world-on-risc-v-with-qemu
 [spike]: https://github.com/riscv/riscv-isa-sim
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ As of this writing, these are the latest versions of the software involved:
 
 TODO: install Spike
 
+Make targets
+------------
+
 `make run-spike` -- build RISC-V ELF executable and launch it via SPIKE.
 
 [riscv-qemu-docs]: https://risc-v-getting-started-guide.readthedocs.io/en/latest/linux-qemu.html

--- a/baremetal-fib.ld
+++ b/baremetal-fib.ld
@@ -1,0 +1,19 @@
+OUTPUT_ARCH( "riscv" )
+OUTPUT_FORMAT("elf64-littleriscv")
+ENTRY( _start )
+SECTIONS
+{
+  /* text: test code section */
+  . = 0x80000000;
+  .text : { *(.text) }
+  /* data: Initialized data segment */
+  .rodata : { *(.rodata) }
+  .data : { *(.data) }
+  .sdata : { *(.sdata) }
+  .debug : { *(.debug) }
+  . += 0x8000;
+  stack_top = .;
+
+  /* End of uninitalized data segement */
+  _end = .;
+}

--- a/baremetal-fib.s
+++ b/baremetal-fib.s
@@ -21,7 +21,7 @@ main:
         call    prints
 
         # test printd and prints functions
-        li      a0, 1                   
+        li      a0, 1
         call    printd
         li      a0, 5
         call    printd
@@ -152,20 +152,21 @@ printd:                                 # IN: a0 = decimal number
 
 1:      li      a1, 10                  # radix = 10
         mv      a2, sp                  # store string on stack
-        addi    sp, sp, -1
-        sb      zero, 0(sp)             # null-terminate the string
+        addi    sp, sp, -16             # allocate 16 symbols on stack to be safe
+        addi    a2, a2, -1
+        sb      zero, 0(a2)             # null-terminate the string
 
         # convert integer into the
         # sequence of single digits
         # and push them onto stack
 2:      rem     t0, a0, a1                # modulo radix
         addi    t0, t0, '0'
-        addi    sp, sp, -1
-        sb      t0, 0(sp)
+        addi    a2, a2, -1
+        sb      t0, 0(a2)
         div     a0, a0, a1
         bnez    a0, 2b
 
         # print top of the stack
-        mv      a0, sp
-        mv      sp, a2
+        mv      a0, a2
+        addi    sp, sp, 16              # restore stack pointer (TODO: restore stack pointer after prints not before)
         j       prints

--- a/baremetal-fib.s
+++ b/baremetal-fib.s
@@ -6,12 +6,12 @@
 .globl _start
 
 _start:
-        csrr    a1, mhartid             # read our hartid and only run on processor 0
-        bne     a1, zero, halt
+        csrr    a1, mhartid             # read our hartware thread id (`hart` stands for `hardware thread`)
+        bnez    a1, halt                # run only on one hardware thread (hardid == 0), halt all the other ones
 
-        la      sp, stack_top
+        la      sp, stack_top           # setup stack pointer
 
-        jal     main
+        jal     main                    # call main()
 
 halt:   j       halt
 
@@ -20,6 +20,7 @@ main:
         la      a0, hello_msg
         jal     prints
 
+        # test printd and prints functions
         li      a0, 1
         jal     printd
         li      a0, 5
@@ -37,6 +38,7 @@ main:
         la      a0, next_line
         jal     prints
 
+        # calculate Fibonacci sequence
         # for (int i = 1; i < 15; i++)
         li      s0, 1
         li      s1, 15

--- a/baremetal-fib.s
+++ b/baremetal-fib.s
@@ -18,25 +18,25 @@ halt:   j       halt
 .global main
 main:
         la      a0, hello_msg
-        jal     prints
+        call    prints
 
         # test printd and prints functions
-        li      a0, 1
-        jal     printd
+        li      a0, 1                   
+        call    printd
         li      a0, 5
-        jal     printd
+        call    printd
         li      a0, 10
-        jal     printd
+        call    printd
         li      a0, 100
-        jal     printd
+        call    printd
         li      a0, 130
-        jal     printd
+        call    printd
         li      a0, -130
-        jal     printd
+        call    printd
         li      a0, -255
-        jal     printd
+        call    printd
         la      a0, next_line
-        jal     prints
+        call    prints
 
         # calculate Fibonacci sequence
         # for (int i = 1; i < 15; i++)
@@ -44,18 +44,18 @@ main:
         li      s1, 15
         # printf("fib(%d) = %d\n", i, fib(i));
 1:      la      a0, fib0_msg
-        jal     prints                    # print "fib("
+        call    prints                    # print "fib("
         mv      a0, s0
-        jal     printd                    # print "%d"
+        call    printd                    # print "%d"
         mv      a0, s0
-        jal     fib                       # call fib()
+        call    fib                       # call fib()
         mv      s2, a0
         la      a0, fib1_msg
-        jal     prints                    # print ") ="
+        call    prints                    # print ") ="
         mv      a0, s2
-        jal     printd                    # print "%d"
+        call    printd                    # print "%d"
         la      a0, next_line
-        jal     prints                    # print "\n"
+        call    prints                    # print "\n"
         addi    s0, s0, 1
         blt     s0, s1, 1b
 

--- a/baremetal-fib.s
+++ b/baremetal-fib.s
@@ -1,0 +1,169 @@
+.align 2
+.equ UART_BASE,         0x10010000
+.equ UART_REG_TXFIFO,   0
+
+.section .text
+.globl _start
+
+_start:
+        csrr    a1, mhartid             # read our hartid and only run on processor 0
+        bne     a1, zero, halt
+
+        la      sp, stack_top
+
+        jal     main
+
+halt:   j       halt
+
+.global main
+main:
+        la      a0, hello_msg
+        jal     prints
+
+        li      a0, 1
+        jal     printd
+        li      a0, 5
+        jal     printd
+        li      a0, 10
+        jal     printd
+        li      a0, 100
+        jal     printd
+        li      a0, 130
+        jal     printd
+        li      a0, -130
+        jal     printd
+        li      a0, -255
+        jal     printd
+        la      a0, next_line
+        jal     prints
+
+        # for (int i = 1; i < 15; i++)
+        li      s0, 1
+        li      s1, 15
+        # printf("fib(%d) = %d\n", i, fib(i));
+1:      la      a0, fib0_msg
+        jal     prints                    # print "fib("
+        mv      a0, s0
+        jal     printd                    # print "%d"
+        mv      a0, s0
+        jal     fib                       # call fib()
+        mv      s2, a0
+        la      a0, fib1_msg
+        jal     prints                    # print ") ="
+        mv      a0, s2
+        jal     printd                    # print "%d"
+        la      a0, next_line
+        jal     prints                    # print "\n"
+        addi    s0, s0, 1
+        blt     s0, s1, 1b
+
+        ret
+
+.global fib
+fib:
+        li      t0, 1
+        li      t1, 2
+
+        beq     a0, t0, 1f
+        beq     a0, t1, 1f
+
+        mv      t0, a0
+        addi    a0, t0, -1              # calculate n-1
+
+        addi    sp, sp, -16
+        sd      ra, 0(sp)
+        sd      t0, 8(sp)               # preserve t0, which contains our original argument
+        jal     fib
+        ld      ra, 0(sp)
+        ld      t0, 8(sp)
+        addi    sp, sp, 16
+
+        mv      t2, a0                  # t2 now contains fib(n-1)
+
+        addi    a0, t0, -2              # calculate n-2
+
+        addi    sp, sp, -16
+        sd      ra, 0(sp)
+        sd      t2, 8(sp)               # preserve t2, which has fib(n-1)
+        jal     fib
+        ld      ra, 0(sp)
+        ld      t2, 8(sp)
+        addi    sp, sp, 16
+
+        mv      t3, a0                  # t3 now contains fib(n-2)
+        add     a0, t2, t3              # add them and jump to return
+        j       2f
+
+1:
+        li      a0, 1
+
+2:
+        ret
+
+.section .rodata
+hello_msg:
+        .string "Hello world!\n"
+fib0_msg:
+        .string "fib("
+fib1_msg:
+        .string ") = "
+next_line:
+        .string "\n"
+
+# --- Utility functions ------------------------------------------------------------
+
+.section .text
+.global printc
+printc:                                 # IN: a0 = char
+        li      a1, UART_BASE
+1:      lw      t1, UART_REG_TXFIFO(a1) # read from serial
+        bltz    t1, 1b                  # until >= 0
+        sw      a0, UART_REG_TXFIFO(a1) # write to serial
+        ret
+
+.global prints
+prints:                                 # IN: a0 = address of NULL terminated string
+        li      a1, UART_BASE
+1:      lbu     t0, (a0)                # load and zero-extend byte from address a0
+        beqz    t0, 3f                  # while not null
+2:      lw      t1, UART_REG_TXFIFO(a1) # read from serial
+        bltz    t1, 2b                  # until >= 0
+        sw      t0, UART_REG_TXFIFO(a1) # write to serial
+        addi    a0, a0, 1               # increment a0
+        j       1b
+3:      ret
+
+.global printd
+printd:                                 # IN: a0 = decimal number
+        # if input is negative,
+        # then print negative sign
+        bgez    a0, 1f
+        neg     a0, a0                  # take two's complement of the input
+        addi    sp, sp, -16
+        sd      ra, 0(sp)
+        sd      a0, 8(sp)
+        li      a0, '-'
+        jal     printc
+        ld      ra, 0(sp)
+        ld      a0, 8(sp)
+        addi    sp, sp, 16
+
+1:      li      a1, 10                  # radix = 10
+        mv      a2, sp                  # store string on stack
+        addi    sp, sp, -1
+        sb      zero, 0(sp)             # null-terminate the string
+
+        # convert integer into the
+        # sequence of single digits
+        # and push them onto stack
+2:      rem     t0, a0, a1                # modulo radix
+        addi    t0, t0, '0'
+        addi    sp, sp, -1
+        sb      t0, 0(sp)
+        div     a0, a0, a1
+        bnez    a0, 2b
+
+        # print top of the stack
+        mv      a0, sp
+        mv      sp, a2
+        j       prints

--- a/baremetal-fib.s
+++ b/baremetal-fib.s
@@ -1,10 +1,6 @@
 .align 2
-.equ UART_BASE,         0x10010000
-.equ UART_REG_TXFIFO,   0
-
 .section .text
 .globl _start
-
 _start:
         csrr    a1, mhartid             # read our hartware thread id (`hart` stands for `hardware thread`)
         bnez    a1, halt                # run only on one hardware thread (hardid == 0), halt all the other ones
@@ -29,16 +25,16 @@ main:
         li      s1, 15
 1:      mv      a0, s0
         jal     fib                     # call fib() with a0 containing index of Fibonacci sequence.
-                                        # The function will return result in a0.
+                                        # fib() will return result in a0.
 
-        addi    sp, sp, -8              # allocate 2 printf arguments (size of int) on stack
+        addi    sp, sp, -8              # allocate 2 int arguments for printf() on the stack
         mv      a1, sp
         sd      s0, 0(a1)               # 1st printf argument s0 contains index i
         sd      a0, 4(a1)               # 2nd prinnt argument a0 contains result of fib(i)
         la      a0, fib_fmt
-        call    printf                  # call printf with a0 pointing to "fib(%d) = %d\n" pattern
-                                        #              and a1 pointing to list of arguments (i, fib(i))
-        addi    sp, sp, 8              # restore stack
+        call    printf                  # call printf() with a0 pointing to "fib(%d) = %d\n" pattern
+                                        #                and a1 pointing to list of arguments [i, fib(i)] stored on stack
+        addi    sp, sp, 8               # restore stack
 
         addi    s0, s0, 1               # i++
         blt     s0, s1, 1b              # loop while i < 15
@@ -90,7 +86,7 @@ fib:
 hello_str:
         .string "Hello world!!!\n"
 hello_fmt:
-        .string "%sHello %c%c%c%c%c%c%c %% %d %i %u %o %x %X _start=%p main=%p fib=%p this-str=%p unknown pattern type: %q.\n"
+        .string "%sHello %% %c%c%c%c%c%c%c: %d %i %u %o %x %X _start=%p main=%p fib=%p this-str=%p unknown pattern type: %q.\n"
 hello_arg:
         .dword hello_str
         .ascii "numbers"
@@ -106,183 +102,3 @@ hello_arg:
         .dword hello_fmt
 fib_fmt:
         .string "fib(%d) = %d\n"
-
-# --- Utility functions ------------------------------------------------------------
-
-.section .text
-.global printf
-.macro  call_printf_arg_handler label, load_op, size
-        addi    sp, sp, -24
-        sd      ra, 0(sp)
-        sd      a0, 8(sp)
-        sd      a1, 16(sp)
-        \load_op a0, (a1)
-        jal     \label
-        ld      ra, 0(sp)
-        ld      a0, 8(sp)
-        ld      a1, 16(sp)
-        addi    sp, sp, 24
-        addi    a1, a1, \size
-.endm
-.macro  push_printf_state
-        addi    sp, sp, -24
-        sd      ra, 0(sp)
-        sd      a0, 8(sp)
-        sd      a1, 16(sp)
-.endm
-.macro  pop_printf_state
-        ld      ra, 0(sp)
-        ld      a0, 8(sp)
-        ld      a1, 16(sp)
-        addi    sp, sp, 24
-.endm
-
-printf:                                 # IN: a0 = address of NULL terminated formatted string, a1 = address of argmuments
-                                        # formatting supports %s, %c, %d, %i, %u, %x, %o, %p
-0:      lbu     t0, (a0)                # load and zero-extend byte from address a0
-        bnez    t0, 1f
-        ret                             # while not null
-
-1:      li      t1, '%'                 # handle %
-        beq     t0, t1, 10f
-2:      li      t2, UART_BASE
-3:      lw      t1, UART_REG_TXFIFO(t2) # read from serial
-        bltz    t1, 3b                  # until >= 0
-        sw      t0, UART_REG_TXFIFO(t2) # write to serial
-        addi    a0, a0, 1               # increment a6
-        j       0b                      # continue
-
-10:     addi    a0, a0, 2
-        lbu     t0, -1(a0)              # read next character to determine type field (%s, %c, %d, %i, %u, %x, %o, %p)
-
-        li      t1, '%'                 # if %%
-        bne     t0, t1, 10f
-        addi    a0, a0, -1              # print % and don't skip the next character
-        j       2b
-
-10:     li      t1, 'c'                 # if %c
-        bne     t0, t1, 10f
-        # load char from a1, increment a1 by sizeof(char), print char
-        call_printf_arg_handler printc, load_op=lbu, size=1
-        j       0b                      # continue
-
-10:     li      t1, 's'                 # if %s
-        bne     t0, t1, 10f
-        # load string pointer from a1, increment a1 by sizeof(char*), print null-terminated string
-        call_printf_arg_handler prints, load_op=ld, size=8
-        j       0b                      # continue
-
-10:     li      t1, 'd'                 # if %d
-        beq     t0, t1, 1f
-        li      t1, 'i'                 # if %i
-        bne     t0, t1, 10f
-1:      # load int from a1, increment a1 by sizeof(int), print int
-        call_printf_arg_handler printd, load_op=lw, size=4
-        j       0b                      # continue
-
-10:     li      t1, 'u'                 # if %u
-        bne     t0, t1, 10f
-        # load unsigned int from a1, increment a1 by sizeof(unsigned), print unsigned
-        call_printf_arg_handler printu, load_op=lwu, size=4
-        j       0b                      # continue
-
-10:     li      t1, 'o'                 # if %o
-        bne     t0, t1, 10f
-        # load unsigned int from a1, increment a1 by sizeof(unsigned), print unsigned as octal
-        call_printf_arg_handler printo, load_op=lwu, size=4
-        j       0b                      # continue
-
-10:     li      t1, 'x'                 # if %x
-        beq     t0, t1, 1f
-        li      t1, 'X'                 # if %X
-        bne     t0, t1, 10f
-1:      # load unsigned int from a1, increment a1 by sizeof(unsigned), print unsigned as hexadecimal
-        call_printf_arg_handler printx, load_op=lwu, size=4
-        j       0b                      # continue
-
-10:     li      t1, 'p'                 # if %p
-        bne     t0, t1, 10f
-
-        push_printf_state
-        li      a0, '0'
-        jal     printc
-        li      a0, 'x'
-        jal     printc                  # print '0x' in front of the address
-        pop_printf_state
-        # load void* pointer from a1, increment a1 by sizeof(void*), print pointer address as hexadecimal
-        call_printf_arg_handler printx, load_op=ld, size=8
-        j       0b                      # continue
-
-10:     addi    a0, a0, -2              # unknown argument
-        lbu     t0, (a0)                # go back and print as characters
-        j       2b
-
-.global printc
-printc:                                 # IN: a0 = char
-        li      a1, UART_BASE
-1:      lw      t1, UART_REG_TXFIFO(a1) # read from serial
-        bltz    t1, 1b                  # until >= 0
-        sw      a0, UART_REG_TXFIFO(a1) # write to serial
-        ret
-
-.global prints
-prints:                                 # IN: a0 = address of NULL terminated string
-        li      a1, UART_BASE
-1:      lbu     t0, (a0)                # load and zero-extend byte from address a0
-        beqz    t0, 3f                  # while not null
-2:      lw      t1, UART_REG_TXFIFO(a1) # read from serial
-        bltz    t1, 2b                  # until >= 0
-        sw      t0, UART_REG_TXFIFO(a1) # write to serial
-        addi    a0, a0, 1               # increment a0
-        j       1b
-3:      ret
-
-.global printd
-.global printu
-printd:                                 # IN: a0 = decimal number
-        # if input is negative,
-        # then print negative sign
-        bgez    a0, printu
-        neg     a0, a0                  # take two's complement of the input
-        addi    sp, sp, -16
-        sd      ra, 0(sp)
-        sd      a0, 8(sp)
-        li      a0, '-'
-        jal     printc                  # print '-' in front of the rest
-        ld      ra, 0(sp)
-        ld      a0, 8(sp)
-        addi    sp, sp, 16
-
-printu:
-        li      a1, 10                  # radix = 10
-
-print_radix:
-        mv      a2, sp                  # store string on stack
-        addi    sp, sp, -16             # allocate 16 symbols on stack to be safe
-        addi    a2, a2, -1
-        sb      zero, 0(a2)             # null-terminate the string
-
-        # convert integer into the
-        # sequence of single digits
-        # and push them onto stack
-1:      remu    t0, a0, a1              # modulo radix
-        li      t1, 10
-        blt     t0, t1, 2f              # if t0 > 9
-        addi    t0, t0, 'A'-'0'-10      #     t0 += 'A' - 10
-2:      addi    t0, t0, '0'             # else t0 += '0'
-        addi    a2, a2, -1
-        sb      t0, 0(a2)
-        divu    a0, a0, a1
-        bnez    a0, 1b
-
-        # print top of the stack
-        mv      a0, a2
-        addi    sp, sp, 16              # restore stack pointer (TODO: restore stack pointer after prints not before)
-        j       prints
-
-printo:
-        li      a1, 8
-        j       print_radix
-printx:
-        li      a1, 16
-        j       print_radix

--- a/baremetal-print.s
+++ b/baremetal-print.s
@@ -1,0 +1,181 @@
+.align 2
+.equ UART_BASE,         0x10010000
+.equ UART_REG_TXFIFO,   0
+
+.section .text
+.global printf
+.macro  call_printf_arg_handler label, load_op, size
+        addi    sp, sp, -24
+        sd      ra, 0(sp)
+        sd      a0, 8(sp)
+        sd      a1, 16(sp)
+        \load_op a0, (a1)
+        jal     \label
+        ld      ra, 0(sp)
+        ld      a0, 8(sp)
+        ld      a1, 16(sp)
+        addi    sp, sp, 24
+        addi    a1, a1, \size
+.endm
+.macro  push_printf_state
+        addi    sp, sp, -24
+        sd      ra, 0(sp)
+        sd      a0, 8(sp)
+        sd      a1, 16(sp)
+.endm
+.macro  pop_printf_state
+        ld      ra, 0(sp)
+        ld      a0, 8(sp)
+        ld      a1, 16(sp)
+        addi    sp, sp, 24
+.endm
+
+printf:                                 # IN: a0 = address of NULL terminated formatted string, a1 = address of argmuments
+                                        # formatting supports %s, %c, %d, %i, %u, %x, %o, %p
+0:      lbu     t0, (a0)                # load and zero-extend byte from address a0
+        bnez    t0, 1f
+        ret                             # while not null
+
+1:      li      t1, '%'                 # handle %
+        beq     t0, t1, 10f
+2:      li      t2, UART_BASE
+3:      lw      t1, UART_REG_TXFIFO(t2) # read from serial
+        bltz    t1, 3b                  # until >= 0
+        sw      t0, UART_REG_TXFIFO(t2) # write to serial
+        addi    a0, a0, 1               # increment a6
+        j       0b                      # continue
+
+10:     addi    a0, a0, 2
+        lbu     t0, -1(a0)              # read next character to determine type field (%s, %c, %d, %i, %u, %x, %o, %p)
+
+        li      t1, '%'                 # if %%
+        bne     t0, t1, 10f
+        addi    a0, a0, -1              # print % and don't skip the next character
+        j       2b
+
+10:     li      t1, 'c'                 # if %c
+        bne     t0, t1, 10f
+        # load char from a1, increment a1 by sizeof(char), print char
+        call_printf_arg_handler printc, load_op=lbu, size=1
+        j       0b                      # continue
+
+10:     li      t1, 's'                 # if %s
+        bne     t0, t1, 10f
+        # load string pointer from a1, increment a1 by sizeof(char*), print null-terminated string
+        call_printf_arg_handler prints, load_op=ld, size=8
+        j       0b                      # continue
+
+10:     li      t1, 'd'                 # if %d
+        beq     t0, t1, 1f
+        li      t1, 'i'                 # if %i
+        bne     t0, t1, 10f
+1:      # load int from a1, increment a1 by sizeof(int), print int
+        call_printf_arg_handler printd, load_op=lw, size=4
+        j       0b                      # continue
+
+10:     li      t1, 'u'                 # if %u
+        bne     t0, t1, 10f
+        # load unsigned int from a1, increment a1 by sizeof(unsigned), print unsigned
+        call_printf_arg_handler printu, load_op=lwu, size=4
+        j       0b                      # continue
+
+10:     li      t1, 'o'                 # if %o
+        bne     t0, t1, 10f
+        # load unsigned int from a1, increment a1 by sizeof(unsigned), print unsigned as octal
+        call_printf_arg_handler printo, load_op=lwu, size=4
+        j       0b                      # continue
+
+10:     li      t1, 'x'                 # if %x
+        beq     t0, t1, 1f
+        li      t1, 'X'                 # if %X
+        bne     t0, t1, 10f
+1:      # load unsigned int from a1, increment a1 by sizeof(unsigned), print unsigned as hexadecimal
+        call_printf_arg_handler printx, load_op=lwu, size=4
+        j       0b                      # continue
+
+10:     li      t1, 'p'                 # if %p
+        bne     t0, t1, 10f
+
+        push_printf_state
+        li      a0, '0'
+        jal     printc
+        li      a0, 'x'
+        jal     printc                  # print '0x' in front of the address
+        pop_printf_state
+        # load void* pointer from a1, increment a1 by sizeof(void*), print pointer address as hexadecimal
+        call_printf_arg_handler printx, load_op=ld, size=8
+        j       0b                      # continue
+
+10:     addi    a0, a0, -2              # unknown argument
+        lbu     t0, (a0)                # go back and print as characters
+        j       2b
+
+.global printc
+printc:                                 # IN: a0 = char
+        li      a1, UART_BASE
+1:      lw      t1, UART_REG_TXFIFO(a1) # read from serial
+        bltz    t1, 1b                  # until >= 0
+        sw      a0, UART_REG_TXFIFO(a1) # write to serial
+        ret
+
+.global prints
+prints:                                 # IN: a0 = address of NULL terminated string
+        li      a1, UART_BASE
+1:      lbu     t0, (a0)                # load and zero-extend byte from address a0
+        beqz    t0, 3f                  # while not null
+2:      lw      t1, UART_REG_TXFIFO(a1) # read from serial
+        bltz    t1, 2b                  # until >= 0
+        sw      t0, UART_REG_TXFIFO(a1) # write to serial
+        addi    a0, a0, 1               # increment a0
+        j       1b
+3:      ret
+
+.global printd
+.global printu
+printd:                                 # IN: a0 = decimal number
+        # if input is negative,
+        # then print negative sign
+        bgez    a0, printu
+        neg     a0, a0                  # take two's complement of the input
+        addi    sp, sp, -16
+        sd      ra, 0(sp)
+        sd      a0, 8(sp)
+        li      a0, '-'
+        jal     printc                  # print '-' in front of the rest
+        ld      ra, 0(sp)
+        ld      a0, 8(sp)
+        addi    sp, sp, 16
+
+printu:
+        li      a1, 10                  # radix = 10
+
+print_radix:
+        mv      a2, sp                  # store string on stack
+        addi    sp, sp, -16             # allocate 16 symbols on stack to be safe
+        addi    a2, a2, -1
+        sb      zero, 0(a2)             # null-terminate the string
+
+        # convert integer into the
+        # sequence of single digits
+        # and push them onto stack
+1:      remu    t0, a0, a1              # modulo radix
+        li      t1, 10
+        blt     t0, t1, 2f              # if t0 > 9
+        addi    t0, t0, 'A'-'0'-10      #     t0 += 'A' - 10
+2:      addi    t0, t0, '0'             # else t0 += '0'
+        addi    a2, a2, -1
+        sb      t0, 0(a2)
+        divu    a0, a0, a1
+        bnez    a0, 1b
+
+        # print top of the stack
+        mv      a0, a2
+        addi    sp, sp, 16              # restore stack pointer (TODO: restore stack pointer after prints not before)
+        j       prints
+
+printo:
+        li      a1, 8
+        j       print_radix
+printx:
+        li      a1, 16
+        j       print_radix

--- a/scripts/build-baremetal.sh
+++ b/scripts/build-baremetal.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+RISCV64_GCC="riscv64-linux-gnu-gcc"
+if ! command -v $RISCV64_GCC &> /dev/null
+then
+    RISCV64_GCC="riscv64-unknown-elf-gcc"
+fi
+
+mkdir -pv baremetal
+$RISCV64_GCC -march=rv64g -mabi=lp64 -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -Tbaremetal-fib.ld baremetal-fib.s -o baremetal/fib

--- a/scripts/build-baremetal.sh
+++ b/scripts/build-baremetal.sh
@@ -7,4 +7,4 @@ then
 fi
 
 mkdir -pv baremetal
-$RISCV64_GCC -march=rv64g -mabi=lp64 -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -Tbaremetal-fib.ld baremetal-fib.s -o baremetal/fib
+$RISCV64_GCC -march=rv64g -mabi=lp64 -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -Tbaremetal-fib.ld baremetal-fib.s baremetal-print.s -o baremetal/fib

--- a/scripts/build-elf.sh
+++ b/scripts/build-elf.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+RISCV64_GCC="riscv64-linux-gnu-gcc"
+if ! command -v $RISCV64_GCC &> /dev/null
+then
+    RISCV64_GCC="riscv64-unknown-elf-gcc"
+fi
+
+mkdir -pv generic-elf
+$RISCV64_GCC -static -o generic-elf/hello hello.c hiasm.S

--- a/scripts/build-initrd.sh
+++ b/scripts/build-initrd.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
 
+RISCV64_GCC="riscv64-linux-gnu-gcc"
+if ! command -v $RISCV64_GCC &> /dev/null
+then
+    RISCV64_GCC="riscv64-unknown-elf-gcc"
+fi
+
 mkdir -pv initramfs/riscv64-busybox
 cd initramfs/riscv64-busybox
 mkdir -pv {bin,sbin,etc,proc,sys,usr/{bin,sbin}}
-riscv64-linux-gnu-gcc -static -o usr/bin/hello ../../hello.c ../../hiasm.S
+$RISCV64_GCC -static -o usr/bin/hello ../../hello.c ../../hiasm.S
 cp -av ../../busybox/_install/* .
 cp ../../scripts/init .
 chmod +x init


### PR DESCRIPTION
- Added bare metal RISC-V assembly (no Linux, no stdlib, no C) bootable sample. Supports QEMU `sifive_u` target.
- Implemented basic printf() alternative in RISC-V assembly with the following types supported in formatting: %s, %c, %d, %i, %u, %x, %o, %p.
- Updated Makefile and README with new build targets.
- Made Makefile support prebuilt RISC-V  toolchain.
- Added initial support for standard SPIKE RISC-V simulator.