### PR TITLE
Potential fix for bare metal sample crash on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ Bare metal RISC-V assembly in QEMU
 
 Run a bare metal RISC-V code in QEMU without any OS or C. Based on the source code from [here][riscv-hello-asm] and [here][riscv-hello-asm2].
 
-The code supports 64bit `sifive_u` QEMU emulation target.
+This code is compiled with the [riscv-gnu-toolchain][riscv-gnu-toolchain] and can be run with the QEMU `sifive_u` machine.
 
 As of this writing, these are the latest versions of the software involved:
 * Qemu: `v5.1.0`
-* RISC-V GCC toolchain: `10.1.0`
+* RISC-V GNU toolchain: `10.1.0`
 
 Make targets
 ------------
@@ -29,7 +29,7 @@ As of this writing, these are the latest versions of the software involved:
 * Qemu: `v5.1.0`
 * Linux: `v5.9`
 * Busybox: `1_9_2`
-* RISC-V GCC toolchain: `10.1.0`
+* RISC-V GNU toolchain: `10.1.0`
 
 Make targets
 ------------
@@ -48,7 +48,7 @@ Run a RISC-V ELF executable in [SPIKE][spike] a standard RISC-V ISA simulator.
 As of this writing, these are the latest versions of the software involved:
 * Qemu: `v5.1.0`
 * Spike" `v1.0.1-dev`
-* RISC-V GCC toolchain: `10.1.0`
+* RISC-V GNU toolchain: `10.1.0`
 
 TODO: install Spike
 
@@ -57,6 +57,7 @@ Make targets
 
 `make run-spike` -- build RISC-V ELF executable and launch it via SPIKE.
 
+[riscv-gnu-toolchain]: https://github.com/riscv/riscv-gnu-toolchain
 [riscv-qemu-docs]: https://risc-v-getting-started-guide.readthedocs.io/en/latest/linux-qemu.html
 [custom-kernel-tutorial]: http://mgalgs.github.io/2015/05/16/how-to-build-a-custom-linux-kernel-for-qemu-2015-edition.html
 [riscv-hello-asm]: https://github.com/noteed/riscv-hello-asm

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The code supports 64bit `sifive_u` QEMU emulation target.
 
 As of this writing, these are the latest versions of the software involved:
 * Qemu: `v5.1.0`
+* RISC-V GCC toolchain: `10.1.0`
 
 Make targets
 ------------
@@ -28,6 +29,7 @@ As of this writing, these are the latest versions of the software involved:
 * Qemu: `v5.1.0`
 * Linux: `v5.9`
 * Busybox: `1_9_2`
+* RISC-V GCC toolchain: `10.1.0`
 
 Make targets
 ------------
@@ -46,6 +48,7 @@ Run a RISC-V ELF executable in [SPIKE][spike] a standard RISC-V ISA simulator.
 As of this writing, these are the latest versions of the software involved:
 * Qemu: `v5.1.0`
 * Spike" `v1.0.1-dev`
+* RISC-V GCC toolchain: `10.1.0`
 
 TODO: install Spike
 

--- a/baremetal-fib.ld
+++ b/baremetal-fib.ld
@@ -9,8 +9,8 @@ SECTIONS
   /* data: Initialized data segment */
   .rodata : { *(.rodata) }
   /* build-id: Store after readonly data */
+  build_id = .;
   .gnu_build_id : { *(.note.gnu.build-id) }
-  gnu_build_id = .;
   .data : { *(.data) }
   .sdata : { *(.sdata) }
   .debug : { *(.debug) }

--- a/baremetal-fib.ld
+++ b/baremetal-fib.ld
@@ -8,6 +8,9 @@ SECTIONS
   .text : { *(.text) }
   /* data: Initialized data segment */
   .rodata : { *(.rodata) }
+  /* build-id: Store after readonly data */
+  .gnu_build_id : { *(.note.gnu.build-id) }
+  gnu_build_id = .;
   .data : { *(.data) }
   .sdata : { *(.sdata) }
   .debug : { *(.debug) }

--- a/baremetal-fib.s
+++ b/baremetal-fib.s
@@ -2,8 +2,8 @@
 .section .text
 .globl _start
 _start:
-        csrr    a1, mhartid             # read our hartware thread id (`hart` stands for `hardware thread`)
-        bnez    a1, halt                # run only on one hardware thread (hardid == 0), halt all the other ones
+        csrr    a1, mhartid             # read hardware thread id (`hart` stands for `hardware thread`)
+        bnez    a1, halt                # run only on the first hardware thread (hartid == 0), halt all the other threads
 
         la      sp, stack_top           # setup stack pointer
 


### PR DESCRIPTION
- Moved GNUs build-id section after the readonly data.
- Fixed wording in comments and README, added a link to RISC-V toolchain.